### PR TITLE
Fix okhttp3 issue with module info

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module info.movito.themoviedbapi {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
     requires okhttp3;
+    requires kotlin.stdlib;
 
     opens info.movito.themoviedbapi.model.account to com.fasterxml.jackson.databind;
     opens info.movito.themoviedbapi.model.authentication to com.fasterxml.jackson.databind;


### PR DESCRIPTION
when using okhttp3 and module-info, it is currently required to also require `kotlin.stdlib`, otherwise it will cause an exception when trying to call TmdbApi constructor with a string api key.