### PR TITLE
fix: Make revenue long instead of int

### DIFF
--- a/src/main/java/info/movito/themoviedbapi/model/movies/MovieDb.java
+++ b/src/main/java/info/movito/themoviedbapi/model/movies/MovieDb.java
@@ -68,7 +68,7 @@ public class MovieDb extends IdElement {
     private String releaseDate;
 
     @JsonProperty("revenue")
-    private Integer revenue;
+    private Long revenue;
 
     @JsonProperty("runtime")
     private Integer runtime;

--- a/src/test/resources/api_responses/movies/details.json
+++ b/src/test/resources/api_responses/movies/details.json
@@ -81,7 +81,7 @@
         }
     ],
     "release_date": "1999-10-15",
-    "revenue": 100853753,
+    "revenue": 2800000000,
     "runtime": 139,
     "spoken_languages": [
         {

--- a/src/test/resources/api_responses/movies/details_with_append_to_response.json
+++ b/src/test/resources/api_responses/movies/details_with_append_to_response.json
@@ -63,7 +63,7 @@
         }
     ],
     "release_date": "2004-11-18",
-    "revenue": 1408947,
+    "revenue": 2800000000,
     "runtime": 92,
     "spoken_languages": [
         {

--- a/src/test/resources/api_responses/movies/latest.json
+++ b/src/test/resources/api_responses/movies/latest.json
@@ -81,7 +81,7 @@
         }
     ],
     "release_date": "1999-10-15",
-    "revenue": 100853753,
+    "revenue": 2800000000,
     "runtime": 139,
     "spoken_languages": [
         {


### PR DESCRIPTION
When trying to load some movies from TMDB I ran into an issue where revenue was larger than the allowed range for an Integer.

```
Unable to update media with TMDB ID 299534: com.fasterxml.jackson.databind.JsonMappingException: Numeric value (2800000000) out of range of int (-2147483648 - 2147483647)
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1205] (through reference chain: info.movito.themoviedbapi.model.movies.MovieDb["revenue"])
```

Updated the latest movies json to have a high revenue so this error will be caught if it regresses.