### PR TITLE
Replace okhttp3 with Java standard library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,6 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok:1.18.32'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.32'
 
-    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.1'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.17.1'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'

--- a/src/main/java/info/movito/themoviedbapi/tools/ApiUrl.java
+++ b/src/main/java/info/movito/themoviedbapi/tools/ApiUrl.java
@@ -93,7 +93,7 @@ public class ApiUrl {
      */
     public void addPathParam(String name, String value) {
         if (params.containsKey(name)) {
-            throw new RuntimeException("paramater '" + name + "' already defined");
+            throw new RuntimeException("parameter '" + name + "' already defined");
         }
 
         name = StringUtils.trimToEmpty(name);

--- a/src/main/java/info/movito/themoviedbapi/tools/ApiUrl.java
+++ b/src/main/java/info/movito/themoviedbapi/tools/ApiUrl.java
@@ -1,7 +1,5 @@
 package info.movito.themoviedbapi.tools;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -59,20 +57,15 @@ public class ApiUrl {
      *
      * @return the URL.
      */
-    public URL buildUrl() {
+    public String buildUrl() {
         StringBuilder urlBuilder = new StringBuilder(baseUrl);
 
-        try {
-            for (Map.Entry<String, String> entry : params.entrySet()) {
-                urlBuilder.append(urlBuilder.toString().contains("?") ? "&" : "?")
-                    .append(entry.getKey()).append("=").append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
-            }
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            urlBuilder.append(urlBuilder.toString().contains("?") ? "&" : "?")
+                .append(entry.getKey()).append("=").append(URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8));
+        }
 
-            return new URL(urlBuilder.toString());
-        }
-        catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
+        return urlBuilder.toString();
     }
 
     /**

--- a/src/main/java/info/movito/themoviedbapi/tools/TmdbUrlReader.java
+++ b/src/main/java/info/movito/themoviedbapi/tools/TmdbUrlReader.java
@@ -1,7 +1,5 @@
 package info.movito.themoviedbapi.tools;
 
-import java.net.URL;
-
 import info.movito.themoviedbapi.model.core.responses.TmdbResponseException;
 
 /**
@@ -17,5 +15,5 @@ public interface TmdbUrlReader {
      * @return the response from the movie database api
      * @throws TmdbResponseException if the response was not successful
      */
-    String readUrl(URL url, String jsonBody, RequestType requestType) throws TmdbResponseException;
+    String readUrl(String url, String jsonBody, RequestType requestType) throws TmdbResponseException;
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,8 +5,7 @@ module info.movito.themoviedbapi {
     requires com.fasterxml.jackson.annotation;
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
-    requires okhttp3;
-    requires kotlin.stdlib;
+    requires java.net.http;
 
     opens info.movito.themoviedbapi.model.account to com.fasterxml.jackson.databind;
     opens info.movito.themoviedbapi.model.authentication to com.fasterxml.jackson.databind;

--- a/src/test/java/info/movito/themoviedbapi/TmdbAccountTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbAccountTest.java
@@ -19,7 +19,6 @@ import info.movito.themoviedbapi.util.TestUtils;
 import info.movito.themoviedbapi.util.Utils;
 import org.junit.jupiter.api.Test;
 
-import static info.movito.themoviedbapi.AbstractTmdbApi.getObjectMapper;
 import static info.movito.themoviedbapi.TmdbAccount.TMDB_METHOD_ACCOUNT;
 import static info.movito.themoviedbapi.tools.ApiUrl.TMDB_API_BASE_URL;
 import static info.movito.themoviedbapi.util.TestUtils.validateAbstractJsonMappingFields;
@@ -65,7 +64,7 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         requestBody.put("media_type", mediaType.toString());
         requestBody.put("media_id", mediaId);
         requestBody.put("favorite", true);
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         String body = TestUtils.readTestFile("api_responses/account/add_favourite.json");
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
@@ -91,7 +90,7 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         requestBody.put("media_type", mediaType.toString());
         requestBody.put("media_id", mediaId);
         requestBody.put("favorite", false);
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         String body = TestUtils.readTestFile("api_responses/account/add_favourite.json");
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
@@ -117,7 +116,7 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         requestBody.put("media_type", mediaType.toString());
         requestBody.put("media_id", mediaId);
         requestBody.put("watchlist", true);
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         String body = TestUtils.readTestFile("api_responses/account/add_to_watchlist.json");
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
@@ -143,7 +142,7 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         requestBody.put("media_type", mediaType.toString());
         requestBody.put("media_id", mediaId);
         requestBody.put("watchlist", false);
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         String body = TestUtils.readTestFile("api_responses/account/add_to_watchlist.json");
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);

--- a/src/test/java/info/movito/themoviedbapi/TmdbAccountTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbAccountTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.HashMap;
 
 import info.movito.themoviedbapi.model.account.Account;
@@ -43,7 +42,7 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
     @Test
     public void testGetAccount() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/account/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234?session_id=testSessionId");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234?session_id=testSessionId";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Account account = getApiToTest().getDetails(1234, "testSessionId");
@@ -61,7 +60,7 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer mediaId = 1234;
         TmdbAccount.MediaType mediaType = TmdbAccount.MediaType.MOVIE;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234/favorite?session_id=testSessionId");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234/favorite?session_id=testSessionId";
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("media_type", mediaType.toString());
         requestBody.put("media_id", mediaId);
@@ -87,7 +86,7 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer mediaId = 1234;
         TmdbAccount.MediaType mediaType = TmdbAccount.MediaType.MOVIE;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234/favorite?session_id=testSessionId");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234/favorite?session_id=testSessionId";
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("media_type", mediaType.toString());
         requestBody.put("media_id", mediaId);
@@ -113,7 +112,7 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer mediaId = 1234;
         TmdbAccount.MediaType mediaType = TmdbAccount.MediaType.MOVIE;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234/watchlist?session_id=testSessionId");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234/watchlist?session_id=testSessionId";
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("media_type", mediaType.toString());
         requestBody.put("media_id", mediaId);
@@ -139,7 +138,7 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer mediaId = 1234;
         TmdbAccount.MediaType mediaType = TmdbAccount.MediaType.MOVIE;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234/watchlist?session_id=testSessionId");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234/watchlist?session_id=testSessionId";
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("media_type", mediaType.toString());
         requestBody.put("media_id", mediaId);
@@ -166,8 +165,8 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer page = 1;
         AccountSortBy sortBy = AccountSortBy.CREATED_AT_ASC;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
-            "/1234/favorite/movies?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
+            "/1234/favorite/movies?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc";
         String body = TestUtils.readTestFile("api_responses/account/favourite_movies.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
@@ -187,8 +186,8 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer page = 1;
         AccountSortBy sortBy = AccountSortBy.CREATED_AT_ASC;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
-            "/1234/favorite/tv?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
+            "/1234/favorite/tv?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc";
         String body = TestUtils.readTestFile("api_responses/account/favourite_tv.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
@@ -206,7 +205,7 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         String sessionId = "testSessionId";
         Integer page = 1;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234/lists?session_id=testSessionId&page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT + "/1234/lists?session_id=testSessionId&page=1";
         String body = TestUtils.readTestFile("api_responses/account/lists.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
@@ -226,8 +225,8 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer page = 1;
         AccountSortBy sortBy = AccountSortBy.CREATED_AT_ASC;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
-            "/1234/rated/movies?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
+            "/1234/rated/movies?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc";
         String body = TestUtils.readTestFile("api_responses/account/rated_movies.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
@@ -247,8 +246,8 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer page = 1;
         AccountSortBy sortBy = AccountSortBy.CREATED_AT_ASC;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
-            "/1234/rated/tv?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
+            "/1234/rated/tv?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc";
         String body = TestUtils.readTestFile("api_responses/account/rated_tv.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
@@ -268,8 +267,8 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer page = 1;
         AccountSortBy sortBy = AccountSortBy.CREATED_AT_ASC;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
-            "/1234/rated/tv/episodes?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
+            "/1234/rated/tv/episodes?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc";
         String body = TestUtils.readTestFile("api_responses/account/rated_tv_episodes.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
@@ -290,8 +289,8 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer page = 1;
         AccountSortBy sortBy = AccountSortBy.CREATED_AT_ASC;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
-            "/1234/watchlist/movies?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
+            "/1234/watchlist/movies?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc";
         String body = TestUtils.readTestFile("api_responses/account/watchlist_movies.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
@@ -311,8 +310,8 @@ public class TmdbAccountTest extends AbstractTmdbApiTest<TmdbAccount> {
         Integer page = 1;
         AccountSortBy sortBy = AccountSortBy.CREATED_AT_ASC;
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
-            "/1234/watchlist/tv?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_ACCOUNT +
+            "/1234/watchlist/tv?session_id=testSessionId&language=en&page=1&sort_by=created_at.asc";
         String body = TestUtils.readTestFile("api_responses/account/watchlist_tv.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 

--- a/src/test/java/info/movito/themoviedbapi/TmdbAuthenticationTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbAuthenticationTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.HashMap;
 
 import info.movito.themoviedbapi.model.authentication.GuestSession;
@@ -43,7 +42,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
     @Test
     public void testCreateGuestSession() throws TmdbException, IOException {
         String body = TestUtils.readTestFile("api_responses/authentication/create_guest_session.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/guest_session/new");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/guest_session/new";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         GuestSession guestSession = getApiToTest().createGuestSession();
@@ -57,7 +56,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
     @Test
     public void testCreateRequestToken() throws TmdbException, IOException {
         String body = TestUtils.readTestFile("api_responses/authentication/create_request_token.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/token/new");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/token/new";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         RequestToken requestToken = getApiToTest().createRequestToken();
@@ -71,7 +70,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
     @Test
     public void testGetTmdbAuthenticationUrlForRequestToken() throws TmdbException, IOException {
         String body = TestUtils.readTestFile("api_responses/authentication/create_request_token.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/token/new");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/token/new";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         RequestToken requestToken = getApiToTest().createRequestToken();
@@ -86,7 +85,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
     @Test
     public void testGetTmdbAuthenticationUrlForRequestTokenUnccessfulRequestToken() throws TmdbException, IOException {
         String body = TestUtils.readTestFile("api_responses/authentication/create_request_token.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/token/new");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/token/new";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         RequestToken requestToken = getApiToTest().createRequestToken();
@@ -107,7 +106,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
         requestBody.put("request_token", requestTokenStr);
         String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/session/new");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/session/new";
         String body = TestUtils.readTestFile("api_responses/authentication/create_session.json");
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
 
@@ -144,7 +143,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
         requestBody.put("request_token", requestToken.getRequestToken());
         String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/token/validate_with_login");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/token/validate_with_login";
         String body = TestUtils.readTestFile("api_responses/authentication/create_session_with_login.json");
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
 
@@ -174,7 +173,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
         requestBody.put("session_id", "sessionId");
         String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/session");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/session";
         String body = TestUtils.readTestFile("api_responses/authentication/delete_session.json");
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.DELETE)).thenReturn(body);
 
@@ -198,7 +197,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
      */
     @Test
     public void testValidateKey() throws TmdbException, IOException {
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_AUTH);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH;
         String body = TestUtils.readTestFile("api_responses/authentication/validate_key.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
@@ -214,7 +213,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
      */
     @Test
     public void testValidateKeyUnsuccessful() throws IOException, TmdbException {
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_AUTH);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH;
         String body = TestUtils.readTestFile("api_responses/authentication/validate_key_unsuccessful.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 

--- a/src/test/java/info/movito/themoviedbapi/TmdbAuthenticationTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbAuthenticationTest.java
@@ -15,7 +15,6 @@ import info.movito.themoviedbapi.util.TestUtils;
 import info.movito.themoviedbapi.util.Utils;
 import org.junit.jupiter.api.Test;
 
-import static info.movito.themoviedbapi.AbstractTmdbApi.getObjectMapper;
 import static info.movito.themoviedbapi.TmdbAuthentication.TMDB_METHOD_AUTH;
 import static info.movito.themoviedbapi.tools.ApiUrl.TMDB_API_BASE_URL;
 import static info.movito.themoviedbapi.tools.TmdbResponseCode.INVALID_API_KEY;
@@ -104,7 +103,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
 
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("request_token", requestTokenStr);
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/session/new";
         String body = TestUtils.readTestFile("api_responses/authentication/create_session.json");
@@ -141,7 +140,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
         requestBody.put("username", "username");
         requestBody.put("password", "password");
         requestBody.put("request_token", requestToken.getRequestToken());
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/token/validate_with_login";
         String body = TestUtils.readTestFile("api_responses/authentication/create_session_with_login.json");
@@ -171,7 +170,7 @@ public class TmdbAuthenticationTest extends AbstractTmdbApiTest<TmdbAuthenticati
     public void testDeleteSession() throws TmdbException, IOException {
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("session_id", "sessionId");
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         String url = TMDB_API_BASE_URL + TMDB_METHOD_AUTH + "/session";
         String body = TestUtils.readTestFile("api_responses/authentication/delete_session.json");

--- a/src/test/java/info/movito/themoviedbapi/TmdbCertificationsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbCertificationsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.certifications.CertificationResults;
 import info.movito.themoviedbapi.tools.RequestType;
@@ -32,7 +31,7 @@ public class TmdbCertificationsTest extends AbstractTmdbApiTest<TmdbCertificatio
     @Test
     public void testGetMovieCertifications() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/certifications/movie.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_CERTIFICATIONS + "/" + TMDB_METHOD_MOVIE_CERTIFICATIONS);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_CERTIFICATIONS + "/" + TMDB_METHOD_MOVIE_CERTIFICATIONS;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         CertificationResults movieCertifications = getApiToTest().getMovieCertifications();
@@ -46,7 +45,7 @@ public class TmdbCertificationsTest extends AbstractTmdbApiTest<TmdbCertificatio
     @Test
     public void testGetTvCertifications() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/certifications/tv.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_CERTIFICATIONS + "/" + TMDB_METHOD_TV_CERTIFICATIONS);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_CERTIFICATIONS + "/" + TMDB_METHOD_TV_CERTIFICATIONS;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         CertificationResults tvCertifications = getApiToTest().getTvCertifications();

--- a/src/test/java/info/movito/themoviedbapi/TmdbChangesTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbChangesTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.changes.ChangesResultsPage;
 import info.movito.themoviedbapi.tools.RequestType;
@@ -37,8 +36,8 @@ public class TmdbChangesTest extends AbstractTmdbApiTest<TmdbChanges> {
         int page = 1;
 
         String body = TestUtils.readTestFile("api_responses/changes/movie_list.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/" + TMDB_METHOD_CHANGES +
-            "?start_date=" + startDate + "&end_date=" + endDate + "&page=" + page);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/" + TMDB_METHOD_CHANGES +
+            "?start_date=" + startDate + "&end_date=" + endDate + "&page=" + page;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ChangesResultsPage changesResultsPage = getApiToTest().getMovieChangesList(startDate, endDate, page);
@@ -56,8 +55,8 @@ public class TmdbChangesTest extends AbstractTmdbApiTest<TmdbChanges> {
         int page = 1;
 
         String body = TestUtils.readTestFile("api_responses/changes/people_list.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/" + TMDB_METHOD_CHANGES +
-            "?start_date=" + startDate + "&end_date=" + endDate + "&page=" + page);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/" + TMDB_METHOD_CHANGES +
+            "?start_date=" + startDate + "&end_date=" + endDate + "&page=" + page;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ChangesResultsPage changesResultsPage = getApiToTest().getPeopleChangesList(startDate, endDate, page);
@@ -75,8 +74,8 @@ public class TmdbChangesTest extends AbstractTmdbApiTest<TmdbChanges> {
         int page = 1;
 
         String body = TestUtils.readTestFile("api_responses/changes/tv_list.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/" + TMDB_METHOD_CHANGES +
-            "?start_date=" + startDate + "&end_date=" + endDate + "&page=" + page);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/" + TMDB_METHOD_CHANGES +
+            "?start_date=" + startDate + "&end_date=" + endDate + "&page=" + page;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ChangesResultsPage changesResultsPage = getApiToTest().getTvChangesList(startDate, endDate, page);

--- a/src/test/java/info/movito/themoviedbapi/TmdbCollectionsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbCollectionsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 
 import info.movito.themoviedbapi.model.collections.CollectionInfo;
@@ -37,8 +36,8 @@ public class TmdbCollectionsTest extends AbstractTmdbApiTest<TmdbCollections> {
         String language = "en";
 
         String body = TestUtils.readTestFile("api_responses/collections/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_COLLECTION + "/" +
-            collectionId + "?" + "language=" + language);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_COLLECTION + "/" +
+            collectionId + "?" + "language=" + language;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         CollectionInfo collectionInfo = getApiToTest().getDetails(collectionId, language);
@@ -56,8 +55,8 @@ public class TmdbCollectionsTest extends AbstractTmdbApiTest<TmdbCollections> {
         String language = "en";
 
         String body = TestUtils.readTestFile("api_responses/collections/images.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_COLLECTION + "/" +
-            collectionId + "/images?language=" + language);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_COLLECTION + "/" +
+            collectionId + "/images?language=" + language;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Images images = getApiToTest().getImages(collectionId, language);
@@ -75,8 +74,8 @@ public class TmdbCollectionsTest extends AbstractTmdbApiTest<TmdbCollections> {
         String[] includeImageLanguage = new String[] {"en", "it"};
 
         String body = TestUtils.readTestFile("api_responses/collections/images.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_COLLECTION + "/" +
-            collectionId + "/images?include_image_language=en%2Cit");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_COLLECTION + "/" +
+            collectionId + "/images?include_image_language=en%2Cit";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Images images = getApiToTest().getImages(collectionId, null, includeImageLanguage);
@@ -92,7 +91,7 @@ public class TmdbCollectionsTest extends AbstractTmdbApiTest<TmdbCollections> {
         int collectionId = 1;
 
         String body = TestUtils.readTestFile("api_responses/collections/translations.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_COLLECTION + "/" + collectionId + "/translations");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_COLLECTION + "/" + collectionId + "/translations";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         List<Translation> translations = getApiToTest().getTranslations(collectionId);

--- a/src/test/java/info/movito/themoviedbapi/TmdbCompaniesTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbCompaniesTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.companies.AlternativeNamesResultsPage;
 import info.movito.themoviedbapi.model.companies.Company;
@@ -34,7 +33,7 @@ public class TmdbCompaniesTest extends AbstractTmdbApiTest<TmdbCompanies> {
         int companyId = 1;
 
         String body = TestUtils.readTestFile("api_responses/companies/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_COMPANY + "/" + companyId);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_COMPANY + "/" + companyId;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Company company = getApiToTest().getDetails(companyId);
@@ -50,7 +49,7 @@ public class TmdbCompaniesTest extends AbstractTmdbApiTest<TmdbCompanies> {
         int companyId = 1;
 
         String body = TestUtils.readTestFile("api_responses/companies/alternative_names.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_COMPANY + "/" + companyId + "/alternative_names");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_COMPANY + "/" + companyId + "/alternative_names";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AlternativeNamesResultsPage alternativeNamesResultsPage = getApiToTest().getAlternativeNames(1);
@@ -66,7 +65,7 @@ public class TmdbCompaniesTest extends AbstractTmdbApiTest<TmdbCompanies> {
         int companyId = 1;
 
         String body = TestUtils.readTestFile("api_responses/companies/images.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_COMPANY + "/" + companyId + "/images");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_COMPANY + "/" + companyId + "/images";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ImageResults logoImageResults = getApiToTest().getImages(1);

--- a/src/test/java/info/movito/themoviedbapi/TmdbConfigurationTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbConfigurationTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 
 import info.movito.themoviedbapi.model.configuration.Configuration;
@@ -36,7 +35,7 @@ public class TmdbConfigurationTest extends AbstractTmdbApiTest<TmdbConfiguration
     @Test
     public void testGetDetails() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/configuration/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Configuration configuration = getApiToTest().getDetails();
@@ -50,7 +49,7 @@ public class TmdbConfigurationTest extends AbstractTmdbApiTest<TmdbConfiguration
     @Test
     public void testGetCountries() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/configuration/countries.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION + "/countries");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION + "/countries";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         List<Country> countries = getApiToTest().getCountries(null);
@@ -68,7 +67,7 @@ public class TmdbConfigurationTest extends AbstractTmdbApiTest<TmdbConfiguration
     @Test
     public void testGetJobs() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/configuration/jobs.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION + "/jobs");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION + "/jobs";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         List<Job> jobs = getApiToTest().getJobs();
@@ -86,7 +85,7 @@ public class TmdbConfigurationTest extends AbstractTmdbApiTest<TmdbConfiguration
     @Test
     public void testGetLanguages() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/configuration/languages.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION + "/languages");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION + "/languages";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         List<Language> languages = getApiToTest().getLanguages();
@@ -104,7 +103,7 @@ public class TmdbConfigurationTest extends AbstractTmdbApiTest<TmdbConfiguration
     @Test
     public void testGetPrimaryTranslations() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/configuration/primary_translations.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION + "/primary_translations");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION + "/primary_translations";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         List<String> primaryTranslations = getApiToTest().getPrimaryTranslations();
@@ -121,7 +120,7 @@ public class TmdbConfigurationTest extends AbstractTmdbApiTest<TmdbConfiguration
     @Test
     public void testGetTimezones() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/configuration/timezones.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION + "/timezones");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_CONFIGURATION + "/timezones";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         List<Timezone> timezones = getApiToTest().getTimezones();

--- a/src/test/java/info/movito/themoviedbapi/TmdbDiscoverTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbDiscoverTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.core.MovieResultsPage;
 import info.movito.themoviedbapi.model.core.TvSeriesResultsPage;
@@ -35,7 +34,7 @@ public class TmdbDiscoverTest extends AbstractTmdbApiTest<TmdbDiscover> {
     @Test
     public void testGetMovie() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/discover/movies.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_DISCOVER + "/" + TMDB_METHOD_MOVIE + "?page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_DISCOVER + "/" + TMDB_METHOD_MOVIE + "?page=1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         DiscoverMovieParamBuilder discoverMovieParamBuilder = new DiscoverMovieParamBuilder()
@@ -52,7 +51,7 @@ public class TmdbDiscoverTest extends AbstractTmdbApiTest<TmdbDiscover> {
     @Test
     public void testGetMovieNullBuilder() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/discover/movies.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_DISCOVER + "/" + TMDB_METHOD_MOVIE);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_DISCOVER + "/" + TMDB_METHOD_MOVIE;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieResultsPage movieResultsPage = getApiToTest().getMovie(null);
@@ -66,7 +65,7 @@ public class TmdbDiscoverTest extends AbstractTmdbApiTest<TmdbDiscover> {
     @Test
     public void testGetTv() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/discover/tv.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_DISCOVER + "/" + TMDB_METHOD_TV + "?page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_DISCOVER + "/" + TMDB_METHOD_TV + "?page=1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         DiscoverTvParamBuilder discoverTvParamBuilder = new DiscoverTvParamBuilder()
@@ -83,7 +82,7 @@ public class TmdbDiscoverTest extends AbstractTmdbApiTest<TmdbDiscover> {
     @Test
     public void testGetTvNullBuilder() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/discover/tv.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_DISCOVER + "/" + TMDB_METHOD_TV);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_DISCOVER + "/" + TMDB_METHOD_TV;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesResultsPage tvSeriesResultsPage = getApiToTest().getTv(null);

--- a/src/test/java/info/movito/themoviedbapi/TmdbFindTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbFindTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +32,7 @@ public class TmdbFindTest extends AbstractTmdbApiTest<TmdbFind> {
     @Test
     public void testFindByIdMovieResults() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/find/movie_results.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_FIND + "/nm0000158?external_source=imdb_id");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_FIND + "/nm0000158?external_source=imdb_id";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TmdbFind tmdbFind = new TmdbFind(getTmdbApi());
@@ -61,7 +60,7 @@ public class TmdbFindTest extends AbstractTmdbApiTest<TmdbFind> {
     @Test
     public void testFindByIdPersonResults() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/find/person_results.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_FIND + "/nm0000158?external_source=imdb_id");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_FIND + "/nm0000158?external_source=imdb_id";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TmdbFind tmdbFind = new TmdbFind(getTmdbApi());
@@ -89,7 +88,7 @@ public class TmdbFindTest extends AbstractTmdbApiTest<TmdbFind> {
     @Test
     public void testFindByIdTvResults() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/find/tv_results.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_FIND + "/nm0000158?external_source=imdb_id");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_FIND + "/nm0000158?external_source=imdb_id";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TmdbFind tmdbFind = new TmdbFind(getTmdbApi());
@@ -117,7 +116,7 @@ public class TmdbFindTest extends AbstractTmdbApiTest<TmdbFind> {
     @Test
     public void testFindByIdTvSeasonResults() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/find/tv_season_results.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_FIND + "/nm0000158?external_source=imdb_id");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_FIND + "/nm0000158?external_source=imdb_id";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TmdbFind tmdbFind = new TmdbFind(getTmdbApi());
@@ -145,7 +144,7 @@ public class TmdbFindTest extends AbstractTmdbApiTest<TmdbFind> {
     @Test
     public void testFindByIdTvEpisodeResults() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/find/tv_episode_results.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_FIND + "/nm0000158?external_source=imdb_id");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_FIND + "/nm0000158?external_source=imdb_id";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TmdbFind tmdbFind = new TmdbFind(getTmdbApi());

--- a/src/test/java/info/movito/themoviedbapi/TmdbGenresTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbGenresTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 
 import info.movito.themoviedbapi.model.core.Genre;
@@ -32,7 +31,7 @@ public class TmdbGenresTest extends AbstractTmdbApiTest<TmdbGenre> {
     @Test
     public void testGetMovieList() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/genres/movie_list.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_GENRE + "/movie/list?language=en");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_GENRE + "/movie/list?language=en";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         List<Genre> genres = getApiToTest().getMovieList("en");
@@ -50,7 +49,7 @@ public class TmdbGenresTest extends AbstractTmdbApiTest<TmdbGenre> {
     @Test
     public void testGetTvList() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/genres/tv_list.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_GENRE + "/tv/list?language=en");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_GENRE + "/tv/list?language=en";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         List<Genre> genres = getApiToTest().getTvList("en");

--- a/src/test/java/info/movito/themoviedbapi/TmdbGuestSessionsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbGuestSessionsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.rated.RatedMovieResultsPage;
 import info.movito.themoviedbapi.model.rated.RatedTvEpisodeResultsPage;
@@ -33,7 +32,7 @@ public class TmdbGuestSessionsTest extends AbstractTmdbApiTest<TmdbGuestSessions
     @Test
     public void testGetRatedMovies() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/guest_sessions/rated_movies.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_GUEST_SESSIONS + "/1/rated/movies?language=en&page=1&sort_by=created_at.desc");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_GUEST_SESSIONS + "/1/rated/movies?language=en&page=1&sort_by=created_at.desc";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         RatedMovieResultsPage ratedMovieResultsPage = getApiToTest().getRatedMovies(1, "en", 1, AccountSortBy.CREATED_AT_DESC);
@@ -47,7 +46,7 @@ public class TmdbGuestSessionsTest extends AbstractTmdbApiTest<TmdbGuestSessions
     @Test
     public void testGetRatedTvSeries() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/guest_sessions/rated_tv.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_GUEST_SESSIONS + "/1/rated/tv?language=en&page=1&sort_by=created_at.desc");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_GUEST_SESSIONS + "/1/rated/tv?language=en&page=1&sort_by=created_at.desc";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         RatedTvSeriesResultsPage ratedTvSeriesResultsPage = getApiToTest().getRatedTvSeries(1, "en", 1, AccountSortBy.CREATED_AT_DESC);
@@ -61,8 +60,8 @@ public class TmdbGuestSessionsTest extends AbstractTmdbApiTest<TmdbGuestSessions
     @Test
     public void testGetRatedTvEpisodes() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/guest_sessions/rated_tv_episodes.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_GUEST_SESSIONS +
-            "/1/rated/tv/episodes?language=en&page=1&sort_by=created_at.desc");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_GUEST_SESSIONS +
+            "/1/rated/tv/episodes?language=en&page=1&sort_by=created_at.desc";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         RatedTvEpisodeResultsPage ratedTvEpisodesResultsPage = getApiToTest().getRatedTvEpisodes(1, "en", 1,

--- a/src/test/java/info/movito/themoviedbapi/TmdbKeywordsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbKeywordsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.keywords.Keyword;
 import info.movito.themoviedbapi.tools.RequestType;
@@ -30,7 +29,7 @@ public class TmdbKeywordsTest extends AbstractTmdbApiTest<TmdbKeywords> {
     @Test
     public void testGetDetails() throws TmdbException, IOException {
         String body = TestUtils.readTestFile("api_responses/keywords/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_KEYWORD + "/1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_KEYWORD + "/1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Keyword keyword = getApiToTest().getDetails(1);

--- a/src/test/java/info/movito/themoviedbapi/TmdbListsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbListsTest.java
@@ -14,7 +14,6 @@ import info.movito.themoviedbapi.util.TestUtils;
 import info.movito.themoviedbapi.util.Utils;
 import org.junit.jupiter.api.Test;
 
-import static info.movito.themoviedbapi.AbstractTmdbApi.getObjectMapper;
 import static info.movito.themoviedbapi.TmdbLists.TMDB_METHOD_LIST;
 import static info.movito.themoviedbapi.tools.ApiUrl.TMDB_API_BASE_URL;
 import static info.movito.themoviedbapi.util.TestUtils.validateAbstractJsonMappingFields;
@@ -41,7 +40,7 @@ public class TmdbListsTest extends AbstractTmdbApiTest<TmdbLists> {
 
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("media_id", 456);
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
 
@@ -92,7 +91,7 @@ public class TmdbListsTest extends AbstractTmdbApiTest<TmdbLists> {
         requestBody.put("name", "testName");
         requestBody.put("description", "testDescription");
         requestBody.put("language", "en-US");
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
 
@@ -140,7 +139,7 @@ public class TmdbListsTest extends AbstractTmdbApiTest<TmdbLists> {
 
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("media_id", 456);
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
 

--- a/src/test/java/info/movito/themoviedbapi/TmdbListsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbListsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.HashMap;
 
 import info.movito.themoviedbapi.model.core.responses.ResponseStatus;
@@ -38,7 +37,7 @@ public class TmdbListsTest extends AbstractTmdbApiTest<TmdbLists> {
     @Test
     public void testAddMovie() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/lists/add_movie.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123/add_item?session_id=testSessionId");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123/add_item?session_id=testSessionId";
 
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("media_id", 456);
@@ -58,7 +57,7 @@ public class TmdbListsTest extends AbstractTmdbApiTest<TmdbLists> {
     @Test
     public void testCheckItemStatus() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/lists/check_item_status.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123/item_status?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123/item_status?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ListItemStatus listItemStatus = getApiToTest().checkItemStatus(123, "en-US", null);
@@ -72,7 +71,7 @@ public class TmdbListsTest extends AbstractTmdbApiTest<TmdbLists> {
     @Test
     public void testClear() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/lists/clear.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123/clear?session_id=testSessionId&confirm=true");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123/clear?session_id=testSessionId&confirm=true";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.POST)).thenReturn(body);
 
         ResponseStatus responseStatus = getApiToTest().clear(123, "testSessionId", true);
@@ -87,7 +86,7 @@ public class TmdbListsTest extends AbstractTmdbApiTest<TmdbLists> {
     @Test
     public void testCreate() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/lists/create.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_LIST + "?session_id=testSessionId");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_LIST + "?session_id=testSessionId";
 
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("name", "testName");
@@ -108,7 +107,7 @@ public class TmdbListsTest extends AbstractTmdbApiTest<TmdbLists> {
     @Test
     public void testDelete() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/lists/delete.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123?session_id=testSessionId");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123?session_id=testSessionId";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.DELETE)).thenReturn(body);
 
         ResponseStatus responseStatus = getApiToTest().delete(123, "testSessionId");
@@ -123,7 +122,7 @@ public class TmdbListsTest extends AbstractTmdbApiTest<TmdbLists> {
     @Test
     public void testGetDetails() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/lists/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ListDetails listDetails = getApiToTest().getDetails(123, "en-US", null);
@@ -137,7 +136,7 @@ public class TmdbListsTest extends AbstractTmdbApiTest<TmdbLists> {
     @Test
     public void testRemoveMovie() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/lists/remove_movie.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123/remove_item?session_id=testSessionId");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_LIST + "/123/remove_item?session_id=testSessionId";
 
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("media_id", 456);

--- a/src/test/java/info/movito/themoviedbapi/TmdbMovieListsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbMovieListsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.core.MovieResultsPage;
 import info.movito.themoviedbapi.model.movielists.MovieResultsPageWithDates;
@@ -31,7 +30,7 @@ public class TmdbMovieListsTest extends AbstractTmdbApiTest<TmdbMovieLists> {
     @Test
     public void testGetNowPlaying() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movie_lists/now_playing.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE_LISTS + "/now_playing?language=en-US&page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE_LISTS + "/now_playing?language=en-US&page=1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieResultsPageWithDates movieResultsPageWithDates = getApiToTest().getNowPlaying("en-US", 1, null);
@@ -45,7 +44,7 @@ public class TmdbMovieListsTest extends AbstractTmdbApiTest<TmdbMovieLists> {
     @Test
     public void testGetPopular() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movie_lists/popular.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE_LISTS + "/popular?language=en-US&page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE_LISTS + "/popular?language=en-US&page=1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieResultsPage movieResultsPage = getApiToTest().getPopular("en-US", 1, null);
@@ -59,7 +58,7 @@ public class TmdbMovieListsTest extends AbstractTmdbApiTest<TmdbMovieLists> {
     @Test
     public void testGetTopRated() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movie_lists/top_rated.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE_LISTS + "/top_rated?language=en-US&page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE_LISTS + "/top_rated?language=en-US&page=1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieResultsPage movieResultsPage = getApiToTest().getTopRated("en-US", 1, null);
@@ -73,7 +72,7 @@ public class TmdbMovieListsTest extends AbstractTmdbApiTest<TmdbMovieLists> {
     @Test
     public void testGetUpcoming() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movie_lists/upcoming.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE_LISTS + "/upcoming?language=en-US&page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE_LISTS + "/upcoming?language=en-US&page=1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieResultsPageWithDates movieResultsPageWithDates = getApiToTest().getUpcoming("en-US", 1, null);

--- a/src/test/java/info/movito/themoviedbapi/TmdbMoviesTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbMoviesTest.java
@@ -30,7 +30,6 @@ import info.movito.themoviedbapi.util.TestUtils;
 import info.movito.themoviedbapi.util.Utils;
 import org.junit.jupiter.api.Test;
 
-import static info.movito.themoviedbapi.AbstractTmdbApi.getObjectMapper;
 import static info.movito.themoviedbapi.TmdbMovies.TMDB_METHOD_MOVIE;
 import static info.movito.themoviedbapi.tools.ApiUrl.TMDB_API_BASE_URL;
 import static info.movito.themoviedbapi.util.TestUtils.validateAbstractJsonMappingFields;
@@ -356,7 +355,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     public void testAddRating() throws IOException, TmdbException {
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("value", 2.1);
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/rating";
         String body = TestUtils.readTestFile("api_responses/movies/add_rating.json");

--- a/src/test/java/info/movito/themoviedbapi/TmdbMoviesTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbMoviesTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -54,7 +53,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetDetails() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieDb movie = getApiToTest().getDetails(123, "en-US");
@@ -92,9 +91,9 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetDetailsWithAppendToResponse() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/details_with_append_to_response.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123?language=en-US&append_to_response=account_states%2C" +
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123?language=en-US&append_to_response=account_states%2C" +
             "alternative_titles%2Ccredits%2Cchanges%2Cexternal_ids%2Cimages%2Ckeywords%2Clists%2Crecommendations%2Crelease_dates%2C" +
-            "reviews%2Csimilar%2Ctranslations%2Cvideos%2Cwatch%2Fproviders");
+            "reviews%2Csimilar%2Ctranslations%2Cvideos%2Cwatch%2Fproviders";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieDb movie = getApiToTest().getDetails(123, "en-US", MovieAppendToResponse.values());
@@ -108,7 +107,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetAccountStates() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/account_states.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/account_states?session_id=123");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/account_states?session_id=123";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AccountStates accountStates = getApiToTest().getAccountStates(123, "123", null);
@@ -122,7 +121,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetAlternativeTitles() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/alternative_titles.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/alternative_titles?country=US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/alternative_titles?country=US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AlternativeTitles alternativeTitles = getApiToTest().getAlternativeTitles(123, "US");
@@ -136,7 +135,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetChanges() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/changes.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/changes");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/changes";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ChangeResults changeResults = getApiToTest().getChanges(123, null, null, null);
@@ -150,7 +149,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetCredits() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/credits.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/credits?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/credits?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Credits credits = getApiToTest().getCredits(123, "en-US");
@@ -164,7 +163,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetExternalIds() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/external_ids.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/external_ids");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/external_ids";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ExternalIds externalIds = getApiToTest().getExternalIds(123);
@@ -178,7 +177,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetImages() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/images.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/images?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/images?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Images images = getApiToTest().getImages(123, "en-US");
@@ -192,7 +191,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetKeywords() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/keywords.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/keywords");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/keywords";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         KeywordResults keywords = getApiToTest().getKeywords(123);
@@ -206,7 +205,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetLatest() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/latest.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/latest");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/latest";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieDb movie = getApiToTest().getLatest();
@@ -244,7 +243,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetLists() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/lists.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/lists?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/lists?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieListResultsPage lists = getApiToTest().getLists(123, "en-US", null);
@@ -258,7 +257,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetRecommendations() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/recommendations.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/recommendations?language=en-US&page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/recommendations?language=en-US&page=1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieResultsPage recommendations = getApiToTest().getRecommendations(123, "en-US", 1);
@@ -272,7 +271,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetReleaseDates() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/release_dates.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/release_dates");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/release_dates";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ReleaseDateResults releaseDates = getApiToTest().getReleaseDates(123);
@@ -286,7 +285,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetReviews() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/reviews.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/reviews?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/reviews?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ReviewResultsPage reviews = getApiToTest().getReviews(123, "en-US", null);
@@ -300,7 +299,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetSimilar() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/similar.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/similar?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/similar?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieResultsPage similar = getApiToTest().getSimilar(123, "en-US", null);
@@ -314,7 +313,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetTranslations() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/translations.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/translations");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/translations";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Translations translations = getApiToTest().getTranslations(123);
@@ -328,7 +327,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetVideos() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/videos.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/videos?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/videos?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         VideoResults videos = getApiToTest().getVideos(123, "en-US");
@@ -342,7 +341,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
     @Test
     public void testGetWatchProviders() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/movies/watch_providers.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/watch/providers");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/watch/providers";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ProviderResults watchProviders = getApiToTest().getWatchProviders(123);
@@ -359,7 +358,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
         requestBody.put("value", 2.1);
         String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/rating");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/rating";
         String body = TestUtils.readTestFile("api_responses/movies/add_rating.json");
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
 
@@ -374,7 +373,7 @@ public class TmdbMoviesTest extends AbstractTmdbApiTest<TmdbMovies> {
      */
     @Test
     public void testDeleteRating() throws IOException, TmdbException {
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/rating");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE + "/123/rating";
         String body = TestUtils.readTestFile("api_responses/movies/delete_rating.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.DELETE)).thenReturn(body);
 

--- a/src/test/java/info/movito/themoviedbapi/TmdbNetworksTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbNetworksTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.core.image.ImageResults;
 import info.movito.themoviedbapi.model.networks.AlternativeNamesResults;
@@ -32,7 +31,7 @@ public class TmdbNetworksTest extends AbstractTmdbApiTest<TmdbNetworks> {
     @Test
     public void testGetMovieChangesList() throws TmdbException, IOException {
         String body = TestUtils.readTestFile("api_responses/networks/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_NETWORK + "/1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_NETWORK + "/1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Network network = getApiToTest().getDetails(1);
@@ -46,7 +45,7 @@ public class TmdbNetworksTest extends AbstractTmdbApiTest<TmdbNetworks> {
     @Test
     public void testGetAlternativeNames() throws TmdbException, IOException {
         String body = TestUtils.readTestFile("api_responses/networks/alternative_names.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_NETWORK + "/1/alternative_names");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_NETWORK + "/1/alternative_names";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AlternativeNamesResults alternativeNamesResults = getApiToTest().getAlternativeNames(1);
@@ -60,7 +59,7 @@ public class TmdbNetworksTest extends AbstractTmdbApiTest<TmdbNetworks> {
     @Test
     public void testGetImages() throws TmdbException, IOException {
         String body = TestUtils.readTestFile("api_responses/networks/images.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_NETWORK + "/1/images");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_NETWORK + "/1/images";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ImageResults imageResults = getApiToTest().getImages(1);

--- a/src/test/java/info/movito/themoviedbapi/TmdbPeopleListsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbPeopleListsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.core.popularperson.PopularPersonResultsPage;
 import info.movito.themoviedbapi.tools.RequestType;
@@ -30,7 +29,7 @@ public class TmdbPeopleListsTest extends AbstractTmdbApiTest<TmdbPeopleLists> {
     @Test
     public void testGetPopular() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/people_lists/popular.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PEOPLE_LISTS + "?language=en-US&page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PEOPLE_LISTS + "?language=en-US&page=1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         PopularPersonResultsPage popularPersonResultsPage = getApiToTest().getPopular("en-US", 1);

--- a/src/test/java/info/movito/themoviedbapi/TmdbPeopleTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbPeopleTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,7 +49,7 @@ public class TmdbPeopleTest extends AbstractTmdbApiTest<TmdbPeople> {
     @Test
     public void testGetDetails() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/people/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         PersonDb details = getApiToTest().getDetails(123, "en-US");
@@ -81,8 +80,8 @@ public class TmdbPeopleTest extends AbstractTmdbApiTest<TmdbPeople> {
     @Test
     public void testGetDetailsWithAppendToResponse() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/people/details_with_append_to_response.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123?language=en-US&" +
-            "append_to_response=changes%2Ccombined_credits%2Cexternal_ids%2Cimages%2Clatest%2Cmovie_credits%2Ctv_credits%2Ctranslations");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123?language=en-US&" +
+            "append_to_response=changes%2Ccombined_credits%2Cexternal_ids%2Cimages%2Clatest%2Cmovie_credits%2Ctv_credits%2Ctranslations";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         PersonDb details = getApiToTest().getDetails(123, "en-US", PersonAppendToResponse.values());
@@ -100,8 +99,8 @@ public class TmdbPeopleTest extends AbstractTmdbApiTest<TmdbPeople> {
         int page = 1;
 
         String body = TestUtils.readTestFile("api_responses/people/changes.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON +
-            "/123/changes?start_date=" + startDate + "&end_date=" + endDate + "&page=" + page);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON +
+            "/123/changes?start_date=" + startDate + "&end_date=" + endDate + "&page=" + page;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ChangeResults changes = getApiToTest().getChanges(123, startDate, endDate, page);
@@ -115,7 +114,7 @@ public class TmdbPeopleTest extends AbstractTmdbApiTest<TmdbPeople> {
     @Test
     public void testGetCombinedCredits() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/people/combined_credits.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/combined_credits?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/combined_credits?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         CombinedPersonCredits personCredits = getApiToTest().getCombinedCredits(123, "en-US");
@@ -150,7 +149,7 @@ public class TmdbPeopleTest extends AbstractTmdbApiTest<TmdbPeople> {
     @Test
     public void testExternalIds() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/people/external_ids.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/external_ids");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/external_ids";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ExternalIds externalIds = getApiToTest().getExternalIds(123);
@@ -164,7 +163,7 @@ public class TmdbPeopleTest extends AbstractTmdbApiTest<TmdbPeople> {
     @Test
     public void testGetImages() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/people/images.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/images");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/images";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         PersonImages images = getApiToTest().getImages(123);
@@ -178,7 +177,7 @@ public class TmdbPeopleTest extends AbstractTmdbApiTest<TmdbPeople> {
     @Test
     public void testGetLatest() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/people/latest.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/latest");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/latest";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         PersonDb latest = getApiToTest().getLatest();
@@ -209,7 +208,7 @@ public class TmdbPeopleTest extends AbstractTmdbApiTest<TmdbPeople> {
     @Test
     public void testGetMovieCredits() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/people/movie_credits.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/movie_credits?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/movie_credits?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieCredits movieCredits = getApiToTest().getMovieCredits(123, "en-US");
@@ -242,7 +241,7 @@ public class TmdbPeopleTest extends AbstractTmdbApiTest<TmdbPeople> {
     @Test
     public void testGetTvCredits() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/people/tv_credits.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/tv_credits?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/tv_credits?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvCredits tvCredits = getApiToTest().getTvCredits(123, "en-US");
@@ -275,7 +274,7 @@ public class TmdbPeopleTest extends AbstractTmdbApiTest<TmdbPeople> {
     @Test
     public void testGetTranslations() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/people/translations.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/translations");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_PERSON + "/123/translations";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Translations translations = getApiToTest().getTranslations(123);

--- a/src/test/java/info/movito/themoviedbapi/TmdbReviewsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbReviewsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.reviews.Review;
 import info.movito.themoviedbapi.tools.RequestType;
@@ -32,7 +31,7 @@ public class TmdbReviewsTest extends AbstractTmdbApiTest<TmdbReviews> {
         int reviewId = 1;
 
         String body = TestUtils.readTestFile("api_responses/reviews/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_MOVIE_REVIEW + "/" + reviewId);
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_MOVIE_REVIEW + "/" + reviewId;
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Review review = getApiToTest().getDetails(reviewId);

--- a/src/test/java/info/movito/themoviedbapi/TmdbTrendingTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbTrendingTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.core.MovieResultsPage;
 import info.movito.themoviedbapi.model.core.TvSeriesResultsPage;
@@ -34,7 +33,7 @@ public class TmdbTrendingTest extends AbstractTmdbApiTest<TmdbTrending> {
     @Test
     public void testGetAll() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/trending/all.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TRENDING + "/all/week?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TRENDING + "/all/week?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MultiResultsPage allResults = getApiToTest().getAll(TimeWindow.WEEK, "en-US");
@@ -48,7 +47,7 @@ public class TmdbTrendingTest extends AbstractTmdbApiTest<TmdbTrending> {
     @Test
     public void testGetMovies() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/trending/movies.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TRENDING + "/movie/week?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TRENDING + "/movie/week?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieResultsPage movieResults = getApiToTest().getMovies(TimeWindow.WEEK, "en-US");
@@ -62,7 +61,7 @@ public class TmdbTrendingTest extends AbstractTmdbApiTest<TmdbTrending> {
     @Test
     public void testGetPeople() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/trending/people.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TRENDING + "/person/week?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TRENDING + "/person/week?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         PopularPersonResultsPage peopleResults = getApiToTest().getPeople(TimeWindow.WEEK, "en-US");
@@ -76,7 +75,7 @@ public class TmdbTrendingTest extends AbstractTmdbApiTest<TmdbTrending> {
     @Test
     public void testGetTv() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/trending/tv.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TRENDING + "/tv/week?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TRENDING + "/tv/week?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesResultsPage tvResults = getApiToTest().getTv(TimeWindow.WEEK, "en-US");

--- a/src/test/java/info/movito/themoviedbapi/TmdbTvEpisodeGroupsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbTvEpisodeGroupsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.tv.episodegroups.EpisodeGroupType;
 import info.movito.themoviedbapi.model.tv.episodegroups.TvEpisodeGroups;
@@ -32,7 +31,7 @@ public class TmdbTvEpisodeGroupsTest extends AbstractTmdbApiTest<TmdbTvEpisodeGr
     @Test
     public void testGetDetails() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episode_groups/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV_EPISODE_GROUPS + "/5acfef37c3a36842e400333f");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV_EPISODE_GROUPS + "/5acfef37c3a36842e400333f";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvEpisodeGroups tvEpisodeGroups = getApiToTest().getDetails("5acfef37c3a36842e400333f");
@@ -46,7 +45,7 @@ public class TmdbTvEpisodeGroupsTest extends AbstractTmdbApiTest<TmdbTvEpisodeGr
     @Test
     public void testEpisodeGroupType() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episode_groups/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV_EPISODE_GROUPS + "/5acfef37c3a36842e400333f");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV_EPISODE_GROUPS + "/5acfef37c3a36842e400333f";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvEpisodeGroups tvEpisodeGroups = getApiToTest().getDetails("5acfef37c3a36842e400333f");

--- a/src/test/java/info/movito/themoviedbapi/TmdbTvEpisodesTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbTvEpisodesTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -49,8 +48,8 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
     @Test
     public void testGetDetails() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episodes/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
-            "/1?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
+            "/1?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvEpisodeDb tvEpisode = getApiToTest().getDetails(123, 1, 1, "en-US");
@@ -80,8 +79,8 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
     @Test
     public void testGetDetailsWithAppendToResponse() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episodes/details_with_append_to_response.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
-            "/1?language=en-US&append_to_response=account_states%2Ccredits%2Cexternal_ids%2Cimages%2Ctranslations%2Cvideos");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
+            "/1?language=en-US&append_to_response=account_states%2Ccredits%2Cexternal_ids%2Cimages%2Ctranslations%2Cvideos";
 
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
@@ -96,8 +95,8 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
     @Test
     public void testGetAccountStates() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episodes/account_states.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
-            "/1/account_states");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
+            "/1/account_states";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AccountStates accountStates = getApiToTest().getAccountStates(123, 1, 1, null, null);
@@ -111,7 +110,7 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
     @Test
     public void testGetChanges() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episodes/changes.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/" + TMDB_METHOD_TV_EPISODE + "/1/changes");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/" + TMDB_METHOD_TV_EPISODE + "/1/changes";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ChangeResults changeResults = getApiToTest().getChanges(1);
@@ -125,8 +124,8 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
     @Test
     public void testGetCredits() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episodes/credits.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
-            "/1/credits?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
+            "/1/credits?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         EpisodeCredits credits = getApiToTest().getCredits(123, 1, 1, "en-US");
@@ -140,8 +139,8 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
     @Test
     public void testGetExternalIds() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episodes/external_ids.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
-            "/1/external_ids");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
+            "/1/external_ids";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ExternalIds externalIds = getApiToTest().getExternalIds(123, 1, 1);
@@ -155,8 +154,8 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
     @Test
     public void testGetImages() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episodes/images.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
-            "/1/images?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
+            "/1/images?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Images images = getApiToTest().getImages(123, 1, 1, "en-US");
@@ -170,8 +169,8 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
     @Test
     public void testGetTranslations() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episodes/translations.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
-            "/1/translations");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
+            "/1/translations";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Translations translations = getApiToTest().getTranslations(123, 1, 1);
@@ -185,8 +184,8 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
     @Test
     public void testGetVideos() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_episodes/videos.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
-            "/1/videos?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
+            "/1/videos?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         VideoResults videoResults = getApiToTest().getVideos(123, 1, 1, "en-US");
@@ -203,8 +202,8 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
         requestBody.put("value", 2.1);
         String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
-            "/1/rating");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
+            "/1/rating";
         String body = TestUtils.readTestFile("api_responses/tv_episodes/add_rating.json");
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
 
@@ -219,8 +218,8 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
      */
     @Test
     public void testDeleteRating() throws IOException, TmdbException {
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
-            "/1/rating");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
+            "/1/rating";
         String body = TestUtils.readTestFile("api_responses/tv_episodes/delete_rating.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.DELETE)).thenReturn(body);
 

--- a/src/test/java/info/movito/themoviedbapi/TmdbTvEpisodesTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbTvEpisodesTest.java
@@ -23,7 +23,6 @@ import info.movito.themoviedbapi.util.TestUtils;
 import info.movito.themoviedbapi.util.Utils;
 import org.junit.jupiter.api.Test;
 
-import static info.movito.themoviedbapi.AbstractTmdbApi.getObjectMapper;
 import static info.movito.themoviedbapi.TmdbTvEpisodes.TMDB_METHOD_TV_EPISODE;
 import static info.movito.themoviedbapi.TmdbTvSeasons.TMDB_METHOD_TV_SEASON;
 import static info.movito.themoviedbapi.TmdbTvSeries.TMDB_METHOD_TV;
@@ -200,7 +199,7 @@ public class TmdbTvEpisodesTest extends AbstractTmdbApiTest<TmdbTvEpisodes> {
     public void testAddRating() throws IOException, TmdbException {
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("value", 2.1);
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/" + TMDB_METHOD_TV_EPISODE +
             "/1/rating";

--- a/src/test/java/info/movito/themoviedbapi/TmdbTvSearchTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbTvSearchTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 
 import info.movito.themoviedbapi.model.core.MovieResultsPage;
@@ -41,7 +40,7 @@ public class TmdbTvSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
     @Test
     public void testSearchCollection() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/search/collection.json");
-        URL url = new URL(TMDB_API_BASE_URL + "search/collection?query=batman&language=en-US");
+        String url = TMDB_API_BASE_URL + "search/collection?query=batman&language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         CollectionResultsPage collectionResultsPage = getApiToTest().searchCollection("batman", "en-US", null, null, null);
@@ -55,7 +54,7 @@ public class TmdbTvSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
     @Test
     public void testSearchCompany() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/search/company.json");
-        URL url = new URL(TMDB_API_BASE_URL + "search/company?query=amici+films");
+        String url = TMDB_API_BASE_URL + "search/company?query=amici+films";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         CompanyResultsPage companyResultsPage = getApiToTest().searchCompany("amici films", null);
@@ -69,7 +68,7 @@ public class TmdbTvSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
     @Test
     public void testSearchKeyword() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/search/keyword.json");
-        URL url = new URL(TMDB_API_BASE_URL + "search/keyword?query=autograph");
+        String url = TMDB_API_BASE_URL + "search/keyword?query=autograph";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         KeywordResultsPage keywordResultsPage = getApiToTest().searchKeyword("autograph", null);
@@ -83,7 +82,7 @@ public class TmdbTvSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
     @Test
     public void testSearchMovie() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/search/movie.json");
-        URL url = new URL(TMDB_API_BASE_URL + "search/movie?query=batman&language=en-US");
+        String url = TMDB_API_BASE_URL + "search/movie?query=batman&language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MovieResultsPage movieResultsPage = getApiToTest().searchMovie("batman", null, "en-US", null, null, null, null);
@@ -97,7 +96,7 @@ public class TmdbTvSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
     @Test
     public void testSearchMulti() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/search/multi.json");
-        URL url = new URL(TMDB_API_BASE_URL + "search/multi?query=batman&language=en-US");
+        String url = TMDB_API_BASE_URL + "search/multi?query=batman&language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         MultiResultsPage multiResultsPage = getApiToTest().searchMulti("batman", null, "en-US", null);
@@ -127,7 +126,7 @@ public class TmdbTvSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
     @Test
     public void testSearchPerson() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/search/person.json");
-        URL url = new URL(TMDB_API_BASE_URL + "search/person?query=vin&language=en-US");
+        String url = TMDB_API_BASE_URL + "search/person?query=vin&language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         PopularPersonResultsPage personResultsPage = getApiToTest().searchPerson("vin", null, "en-US", null);
@@ -141,7 +140,7 @@ public class TmdbTvSearchTest extends AbstractTmdbApiTest<TmdbSearch> {
     @Test
     public void testSearchTv() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/search/tv.json");
-        URL url = new URL(TMDB_API_BASE_URL + "search/tv?query=batman&language=en-US");
+        String url = TMDB_API_BASE_URL + "search/tv?query=batman&language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesResultsPage tvSeriesResultsPage = getApiToTest().searchTv("batman", null, null, "en-US", null, null);

--- a/src/test/java/info/movito/themoviedbapi/TmdbTvSeasonsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbTvSeasonsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,7 +43,7 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetDetails() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeasonDb tvSeason = getApiToTest().getDetails(123, 1, "en-US");
@@ -77,9 +76,9 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetDetailsWithAppendToResponse() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/details_with_append_to_response.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1?language=en-US&" +
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1?language=en-US&" +
             "append_to_response=account_states%2Caggregate_credits%2Ccredits%2Cexternal_ids%2Cimages%2Ctranslations%2C" +
-            "videos%2Cwatch%2Fproviders");
+            "videos%2Cwatch%2Fproviders";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeasonDb tvSeason = getApiToTest().getDetails(123, 1, "en-US", TvSeasonsAppendToResponse.values());
@@ -93,7 +92,7 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetAccountStates() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/account_states.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/account_states?session_id=123");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/account_states?session_id=123";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AccountStateResults accountStates = getApiToTest().getAccountStates(123, 1, "123", null);
@@ -107,7 +106,7 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetAggregateCredits() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/aggregate_credits.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/aggregate_credits?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/aggregate_credits?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AggregateCredits aggregateCredits = getApiToTest().getAggregateCredits(123, 1, "en-US");
@@ -121,7 +120,7 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetChanges() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/changes.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/" + TMDB_METHOD_TV_SEASON + "/123/changes?page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/" + TMDB_METHOD_TV_SEASON + "/123/changes?page=1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ChangeResults changes = getApiToTest().getChanges(123, null, null, 1);
@@ -135,7 +134,7 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetCredits() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/credits.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/credits?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/credits?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Credits credits = getApiToTest().getCredits(123, 1, "en-US");
@@ -149,7 +148,7 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetExternalIds() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/external_ids.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/external_ids");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/external_ids";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ExternalIds externalIds = getApiToTest().getExternalIds(123, 1);
@@ -163,7 +162,7 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetImages() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/images.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/images?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/images?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Images images = getApiToTest().getImages(123, 1, "en-US");
@@ -177,7 +176,7 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetTranslations() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/translations.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/translations");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/translations";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Translations translations = getApiToTest().getTranslations(123, 1);
@@ -191,7 +190,7 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetVideos() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/videos.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/videos?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/videos?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         VideoResults videos = getApiToTest().getVideos(123, 1, "en-US");
@@ -205,7 +204,7 @@ public class TmdbTvSeasonsTest extends AbstractTmdbApiTest<TmdbTvSeasons> {
     @Test
     public void testGetWatchProviders() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_seasons/watch_providers.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/watch/providers?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/" + TMDB_METHOD_TV_SEASON + "/1/watch/providers?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ProviderResults watchProviders = getApiToTest().getWatchProviders(123, 1, "en-US");

--- a/src/test/java/info/movito/themoviedbapi/TmdbTvSeriesListsTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbTvSeriesListsTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 
 import info.movito.themoviedbapi.model.core.TvSeriesResultsPage;
 import info.movito.themoviedbapi.tools.RequestType;
@@ -30,7 +29,7 @@ public class TmdbTvSeriesListsTest extends AbstractTmdbApiTest<TmdbTvSeriesLists
     @Test
     public void testGetAiringToday() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series_lists/airing_today.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/airing_today?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/airing_today?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesResultsPage tvSeriesResultsPage = getApiToTest().getAiringToday("en-US", null, null);
@@ -44,7 +43,7 @@ public class TmdbTvSeriesListsTest extends AbstractTmdbApiTest<TmdbTvSeriesLists
     @Test
     public void testGetOnTheAir() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series_lists/on_the_air.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/on_the_air?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/on_the_air?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesResultsPage tvSeriesResultsPage = getApiToTest().getOnTheAir("en-US", null, null);
@@ -58,7 +57,7 @@ public class TmdbTvSeriesListsTest extends AbstractTmdbApiTest<TmdbTvSeriesLists
     @Test
     public void testGetPopular() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series_lists/popular.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/popular?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/popular?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesResultsPage tvSeriesResultsPage = getApiToTest().getPopular("en-US", null);
@@ -72,7 +71,7 @@ public class TmdbTvSeriesListsTest extends AbstractTmdbApiTest<TmdbTvSeriesLists
     @Test
     public void testGetTopRated() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series_lists/top_rated.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/top_rated?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/top_rated?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesResultsPage tvSeriesResultsPage = getApiToTest().getTopRated("en-US", null);

--- a/src/test/java/info/movito/themoviedbapi/TmdbTvSeriesTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbTvSeriesTest.java
@@ -33,7 +33,6 @@ import info.movito.themoviedbapi.util.TestUtils;
 import info.movito.themoviedbapi.util.Utils;
 import org.junit.jupiter.api.Test;
 
-import static info.movito.themoviedbapi.AbstractTmdbApi.getObjectMapper;
 import static info.movito.themoviedbapi.TmdbTvSeries.TMDB_METHOD_TV;
 import static info.movito.themoviedbapi.tools.ApiUrl.TMDB_API_BASE_URL;
 import static info.movito.themoviedbapi.util.TestUtils.validateAbstractJsonMappingFields;
@@ -407,7 +406,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     public void testAddRating() throws IOException, TmdbException {
         HashMap<String, Object> requestBody = new HashMap<>();
         requestBody.put("value", 2.1);
-        String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
+        String jsonBody = Utils.convertToJson(AbstractTmdbApi.getObjectMapper(), requestBody);
 
         String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/rating";
         String body = TestUtils.readTestFile("api_responses/tv_series/add_rating.json");

--- a/src/test/java/info/movito/themoviedbapi/TmdbTvSeriesTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbTvSeriesTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -57,7 +56,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetDetails() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/details.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesDb tvSeries = getApiToTest().getDetails(123, "en-US");
@@ -98,9 +97,9 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetDetailsWithAppendToResponse() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/details_with_append_to_response.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123?language=en-US&append_to_response=account_states%2Caggregate_credits" +
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123?language=en-US&append_to_response=account_states%2Caggregate_credits" +
             "%2Calternative_titles%2Cchanges%2Ccontent_ratings%2Ccredits%2Cepisode_groups%2Cexternal_ids%2Cimages%2Ckeywords%2Clists" +
-            "%2Crecommendations%2Creviews%2Cscreened_theatrically%2Csimilar%2Ctranslations%2Cvideos%2Cwatch%2Fproviders");
+            "%2Crecommendations%2Creviews%2Cscreened_theatrically%2Csimilar%2Ctranslations%2Cvideos%2Cwatch%2Fproviders";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesDb tvSeries = getApiToTest().getDetails(123, "en-US", TvSeriesAppendToResponse.values());
@@ -114,7 +113,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetAccountStates() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/account_states.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/account_states?session_id=123");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/account_states?session_id=123";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AccountStates accountStates = getApiToTest().getAccountStates(123, "123", null);
@@ -128,7 +127,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetAggregateCredits() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/aggregate_credits.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/aggregate_credits?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/aggregate_credits?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AggregateCredits aggregateCredits = getApiToTest().getAggregateCredits(123, "en-US");
@@ -142,7 +141,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetAlternativeTitles() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/alternative_titles.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/alternative_titles");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/alternative_titles";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AlternativeTitleResults alternativeTitles = getApiToTest().getAlternativeTitles(123);
@@ -156,7 +155,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetChanges() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/changes.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/changes?page=1");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/changes?page=1";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ChangeResults changes = getApiToTest().getChanges(123, null, null, 1);
@@ -170,7 +169,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetContentRatings() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/content_ratings.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/content_ratings");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/content_ratings";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ContentRatingResults contentRatings = getApiToTest().getContentRatings(123);
@@ -184,7 +183,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetCredits() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/credits.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/credits?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/credits?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Credits credits = getApiToTest().getCredits(123, "en-US");
@@ -198,7 +197,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetEpisodeGroups() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/episode_groups.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/episode_groups");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/episode_groups";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         EpisodeGroupResults episodeGroups = getApiToTest().getEpisodeGroups(123);
@@ -212,7 +211,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetExternalIds() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/external_ids.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/external_ids");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/external_ids";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ExternalIds externalIds = getApiToTest().getExternalIds(123);
@@ -226,7 +225,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetImages() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/images.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/images");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/images";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Images images = getApiToTest().getImages(123, null);
@@ -240,7 +239,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetKeywords() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/keywords.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/keywords");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/keywords";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvKeywords keywords = getApiToTest().getKeywords(123);
@@ -254,7 +253,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetLatest() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/latest.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/latest");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/latest";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesDb latest = getApiToTest().getLatest();
@@ -295,7 +294,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetLists() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/lists.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/lists");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/lists";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesListResultsPage lists = getApiToTest().getLists(123, null, null);
@@ -309,7 +308,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetRecommendations() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/recommendations.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/recommendations");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/recommendations";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesResultsPage recommendations = getApiToTest().getRecommendations(123, null, null);
@@ -323,7 +322,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetReviews() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/reviews.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/reviews");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/reviews";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ReviewResultsPage reviews = getApiToTest().getReviews(123, null, null);
@@ -337,7 +336,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetScreenedTheatrically() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/screened_theatrically.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/screened_theatrically");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/screened_theatrically";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ScreenedTheatricallyResults screenedTheatrically = getApiToTest().getScreenedTheatrically(123);
@@ -351,7 +350,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetSimilar() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/similar.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/similar");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/similar";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         TvSeriesResultsPage similar = getApiToTest().getSimilar(123, null, null);
@@ -365,7 +364,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetTranslations() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/translations.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/translations");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/translations";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         Translations translations = getApiToTest().getTranslations(123);
@@ -379,7 +378,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetVideos() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/videos.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/videos");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/videos";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         VideoResults videos = getApiToTest().getVideos(123, null);
@@ -393,7 +392,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
     @Test
     public void testGetWatchProviders() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/tv_series/watch_providers.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/watch/providers");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/watch/providers";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ProviderResults watchProviders = getApiToTest().getWatchProviders(123);
@@ -410,7 +409,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
         requestBody.put("value", 2.1);
         String jsonBody = Utils.convertToJson(getObjectMapper(), requestBody);
 
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/rating");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/rating";
         String body = TestUtils.readTestFile("api_responses/tv_series/add_rating.json");
         when(getTmdbUrlReader().readUrl(url, jsonBody, RequestType.POST)).thenReturn(body);
 
@@ -425,7 +424,7 @@ public class TmdbTvSeriesTest extends AbstractTmdbApiTest<TmdbTvSeries> {
      */
     @Test
     public void testDeleteRating() throws IOException, TmdbException {
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/rating");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_TV + "/123/rating";
         String body = TestUtils.readTestFile("api_responses/tv_series/delete_rating.json");
         when(getTmdbUrlReader().readUrl(url, null, RequestType.DELETE)).thenReturn(body);
 

--- a/src/test/java/info/movito/themoviedbapi/TmdbWatchProvidersTest.java
+++ b/src/test/java/info/movito/themoviedbapi/TmdbWatchProvidersTest.java
@@ -1,7 +1,6 @@
 package info.movito.themoviedbapi;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.Map;
 
 import info.movito.themoviedbapi.model.watchproviders.AvailableRegionResults;
@@ -33,7 +32,7 @@ public class TmdbWatchProvidersTest extends AbstractTmdbApiTest<TmdbWatchProvide
     @Test
     public void testGetAvailableRegions() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/watch_providers/available_regions.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_WATCH_PROVIDERS + "?language=en-US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_WATCH_PROVIDERS + "?language=en-US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         AvailableRegionResults availableRegionResults = getApiToTest().getAvailableRegions("en-US");
@@ -47,7 +46,7 @@ public class TmdbWatchProvidersTest extends AbstractTmdbApiTest<TmdbWatchProvide
     @Test
     public void testGetMovieProviders() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/watch_providers/movie_providers.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_WATCH_PROVIDERS + "/movie?language=en-US&watch_region=US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_WATCH_PROVIDERS + "/movie?language=en-US&watch_region=US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ProviderResults providerResults = getApiToTest().getMovieProviders("en-US", "US");
@@ -69,7 +68,7 @@ public class TmdbWatchProvidersTest extends AbstractTmdbApiTest<TmdbWatchProvide
     @Test
     public void testGetTvProviders() throws IOException, TmdbException {
         String body = TestUtils.readTestFile("api_responses/watch_providers/tv_providers.json");
-        URL url = new URL(TMDB_API_BASE_URL + TMDB_METHOD_WATCH_PROVIDERS + "/tv?language=en-US&watch_region=US");
+        String url = TMDB_API_BASE_URL + TMDB_METHOD_WATCH_PROVIDERS + "/tv?language=en-US&watch_region=US";
         when(getTmdbUrlReader().readUrl(url, null, RequestType.GET)).thenReturn(body);
 
         ProviderResults providerResults = getApiToTest().getTvProviders("en-US", "US");


### PR DESCRIPTION
- replaces okhttp3 with the java standard library http client
- fix a spelling mistake
- expand static imports for lombok generated methods - they don't work with javac