### PR TITLE
add crypto package for linked modules

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module info.movito.themoviedbapi {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
     requires java.net.http;
+    requires jdk.crypto.cryptoki;
 
     opens info.movito.themoviedbapi.model.account to com.fasterxml.jackson.databind;
     opens info.movito.themoviedbapi.model.authentication to com.fasterxml.jackson.databind;


### PR DESCRIPTION
When creating a jlinked module, SSL handshake fails when making the http request because there is no encryption module included by default. This change adds that so applications using this library do not need to require it in their module info.