### PR TITLE
clarify which key to use in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ dependencies {
 </details>
 
 ## Usage
-To register for a TMdB API key, click the [API link](https://www.themoviedb.org/settings/api) from within your account settings page. 
+To register for a TMdB API key, click the [API link](https://www.themoviedb.org/settings/api) from within your account settings page. There are two types of API keys currently provided by TMdB, please ensure you are using the `API Read Access Token` key.
 
 With this you can instantiate `info.movito.themoviedbapi.TmdbApi`, which has getters for all subcategories of the API, e.g.
 ```java


### PR DESCRIPTION
Update the readme to clarify which API key to use, after an issue was submitted about API key errors: #238